### PR TITLE
improve handling status 304 response

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -136,6 +136,7 @@ func (g *Generator) generateOutput(target interface{}) error {
 
 	g.Printf("func makeHeaderFrom%[1]s(out *s3.%[1]s) http.Header {\n", name)
 	g.Printf("header := make(http.Header)\n")
+	g.Printf("if out == nil { return header }\n")
 	num := typ.NumField()
 	for i := 0; i < num; i++ {
 		f := typ.Field(i)

--- a/generated.go
+++ b/generated.go
@@ -144,6 +144,9 @@ func newHeadObjectInput(req *http.Request) *s3.HeadObjectInput {
 
 func makeHeaderFromGetObjectOutput(out *s3.GetObjectOutput) http.Header {
 	header := make(http.Header)
+	if out == nil {
+		return header
+	}
 	if out.AcceptRanges != nil {
 		header.Set("Accept-Ranges", aws.StringValue(out.AcceptRanges))
 	}
@@ -236,6 +239,9 @@ func makeHeaderFromGetObjectOutput(out *s3.GetObjectOutput) http.Header {
 
 func makeHeaderFromHeadObjectOutput(out *s3.HeadObjectOutput) http.Header {
 	header := make(http.Header)
+	if out == nil {
+		return header
+	}
 	if out.AcceptRanges != nil {
 		header.Set("Accept-Ranges", aws.StringValue(out.AcceptRanges))
 	}


### PR DESCRIPTION
`GetObjectWithContext` may return non-nil output with non-nil error.
e.g. If err is 304 not modified, the output contains ETag information.